### PR TITLE
fr_abort() missing kwarg

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,7 +207,7 @@ class UserCommands(Resource):
     def _get_user_checking_credentials(username, api_key):
         user = User.query.filter_by(name=username).first()
         if not user:
-            fr_abort(403, "No such user")
+            fr_abort(403, message="No such user")
 
         if api_key != user.api_key:
             fr_abort(403, message="Wrong API key")


### PR DESCRIPTION
This fixes Internal server error 500. #43

Because I was passing my username in lowercase (nudies) when it should have been Nudies no query was returned triggering fr_abort() which takes status code and **kwargs as params. This caused the 500error. Fixing this returned 403 as expected! :tada: 

```
class UserCommands(Resource):
    @staticmethod
    def _get_user_checking_credentials(username, api_key):
        user = User.query.filter_by(name=username).first()
        if not user:
-            fr_abort(403, "No such user")
+            fr_abort(403, message="No such user")
```
