### PR TITLE
Add humanized time-since on shared commands.

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,36 @@ def url_for_other_page(page):
 app.jinja_env.globals['url_for_other_page'] = url_for_other_page
 
 
+@app.template_filter()
+def timesince(dt, default="just now"):
+    """
+    Jinja filter that takes a datetime and retuns the
+    'human' version of time since said datetime.
+
+    e.g. 28 minutes ago
+    """
+
+    now = datetime.utcnow()
+    diff = now - dt
+    
+    periods = (
+        (diff.days / 365, "year", "years"),
+        (diff.days / 30, "month", "months"),
+        (diff.days / 7, "week", "weeks"),
+        (diff.days, "day", "days"),
+        (diff.seconds / 3600, "hour", "hours"),
+        (diff.seconds / 60, "minute", "minutes"),
+        (diff.seconds, "second", "seconds"),
+    )
+
+    for period, singular, plural in periods:
+        
+        if period:
+            return "%d %s ago" % (period, singular if period == 1 else plural)
+
+    return default
+
+
 @github.access_token_getter
 def token_getter():
     if current_user.is_authenticated():

--- a/app.py
+++ b/app.py
@@ -57,23 +57,8 @@ def timesince(dt, default="just now"):
 
     now = datetime.utcnow()
     diff = now - dt
-    
-    periods = (
-        (diff.days / 365, "year", "years"),
-        (diff.days / 30, "month", "months"),
-        (diff.days / 7, "week", "weeks"),
-        (diff.days, "day", "days"),
-        (diff.seconds / 3600, "hour", "hours"),
-        (diff.seconds / 60, "minute", "minutes"),
-        (diff.seconds, "second", "seconds"),
-    )
 
-    for period, singular, plural in periods:
-        
-        if period:
-            return "%d %s ago" % (period, singular if period == 1 else plural)
-
-    return default
+    return humanize.naturaltime(diff) 
 
 
 @github.access_token_getter

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -28,8 +28,9 @@
     <div class="panel-heading">
       <h5 class="panel-title">
         <span class="public-title public-title-{{command.id}}" {% if not command.is_public %} style="display:none;" {% endif %}>
-          Shared by <a href={{url_for("profile", username=command.user.name)}}>{{command.user.name}}</a>
+			Shared by <a href={{url_for("profile", username=command.user.name)}}>{{command.user.name}}</a> {{ command.time_shared | timesince }}
         </span>
+		<div class="pull-right">
         <span class="private-title private-title-{{command.id}}" {% if command.is_public %} style="display:none;" {% endif %}>
           Private command
         </span>
@@ -38,6 +39,7 @@
                             current_user.is_authenticated() and command.user == current_user,
                             command.is_public,
                             true) }}
+		</div>
       </h5>
     </div>
     <div class="panel-body">


### PR DESCRIPTION
This is my first-ever pull request :) - please forgive me if this is not how it works...

I've added a template filter that 'humanizes' the time since a date (e.g. '2 hours ago') and did a tiny bit of editing in index.html to use it to display the time since a command was shared. (Added the template tag and filter, as well as pulled the command buttons to the right)

Preview:
![](http://i.gyazo.com/374c25644d58c2f97e5b45d34f88112c.png)
